### PR TITLE
Mention Foothill Metabolic work on /now page

### DIFF
--- a/apps/website/src/pages/now.astro
+++ b/apps/website/src/pages/now.astro
@@ -17,12 +17,13 @@ import { SITE_TITLE, SITE_DESCRIPTION } from '../config';
 <main>
   <h1>🆕 now</h1>
   <p>
-    Updated December 8th, 2025. This is a <a href="https://nownownow.com/about">now</a> page, and this is what I'm focused on right now.
+    Updated June 9th, 2026. This is a <a href="https://nownownow.com/about">now</a> page, and this is what I'm focused on right now.
   </p>
 
   <ul>
     <li>Living in <a href="https://www.cityofglendora.org/" target="_blank">Glendora, CA</a></li>
     <li>Running <a target="_blank" href="https://zabaca.com">Zabaca</a> - AI-focused software consultancy</li>
+    <li>Building <a target="_blank" href="https://foothillmetabolic.com">Foothill Metabolic</a> - a current focus area</li>
     <li>Consulting for <a target="_blank" href="https://implentio.com">Implentio</a> on e-commerce logistics reconciliation</li>
     <li>Building <a target="_blank" href="https://github.com/Zabaca/lattice">Lattice</a> - a knowledge graph CLI for markdown documentation</li>
     <li>Building <a target="_blank" href="https://github.com/Zabaca/temporal-bridge">TemporalBridge</a> - AI memory system for Claude Code</li>


### PR DESCRIPTION
Updates the `/now` page to reflect current work on foothillmetabolic.com.

## Changes
- Added **Foothill Metabolic** as a current focus area in the now list
- Refreshed the last-updated date to June 9th, 2026

Closes ticket: UPTO-ZVJGTM