### PR TITLE
Retire Implentio as an active client

### DIFF
--- a/apps/website/src/pages/index.astro
+++ b/apps/website/src/pages/index.astro
@@ -24,17 +24,17 @@ import { SITE_TITLE, SITE_DESCRIPTION } from '../config';
 				AI-focused software consultancy building tools and workflows that enhance developer productivity. Specializing in AI integrations, knowledge graphs, and automation.
 			</p>
 
-			<a href="https://implentio.com" target="_blank">Implentio</a> - Consultant
-			<p>
-				E-commerce logistics reconciliation platform. Helping brands identify shipping discrepancies and recover costs through intelligent invoice processing at scale.
-			</p>
-
 			<a href="https://www.havenproject.io/" target="_blank">Haven</a> - Advisor
 			<p>
 				Haven provides a single search engine to aid SMBs finding government contracts.
 			</p>
 
 			<h2>Past</h2>
+			<a href="https://implentio.com" target="_blank">Implentio</a> - x Consultant
+			<p>
+				E-commerce logistics reconciliation platform. Helping brands identify shipping discrepancies and recover costs through intelligent invoice processing at scale.
+			</p>
+
 			<a href="https://panfactum.com" target="_blank">Panfactum</a> - x CTO
 			<p>
 				The Open-Source Framework for Cloud Infrastructure to launch faster, scale easier at a fraction of the cost.

--- a/apps/website/src/pages/now.astro
+++ b/apps/website/src/pages/now.astro
@@ -23,7 +23,6 @@ import { SITE_TITLE, SITE_DESCRIPTION } from '../config';
   <ul>
     <li>Living in <a href="https://www.cityofglendora.org/" target="_blank">Glendora, CA</a></li>
     <li>Running <a target="_blank" href="https://zabaca.com">Zabaca</a> - AI-focused software consultancy</li>
-    <li>Consulting for <a target="_blank" href="https://implentio.com">Implentio</a> on e-commerce logistics reconciliation</li>
     <li>Building <a target="_blank" href="https://github.com/Zabaca/lattice">Lattice</a> - a knowledge graph CLI for markdown documentation</li>
     <li>Building <a target="_blank" href="https://github.com/Zabaca/temporal-bridge">TemporalBridge</a> - AI memory system for Claude Code</li>
     <li>Deep into <a href="https://www.anthropic.com/claude-code" target="_blank">Claude Code</a> workflows and AI-assisted development</li>


### PR DESCRIPTION
Implentio is no longer an active client.

## Changes
- Removed the Implentio consulting line from the `/now` page
- Moved Implentio from **Current** to **Past** on the home page (`index.astro`)

Closes ticket: UPTO-ZVJGTM